### PR TITLE
move async from devDependencies -> dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "post_coverage": "GRUNT_MOVE_COVERAGE=1 grunt default coveralls"
   },
   "dependencies": {
+    "async": "~2.1.4",
     "chalk": "^1.1.3"
   },
   "devDependencies": {
-    "async": "~2.1.4",
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-copy": "^1.0.0",


### PR DESCRIPTION
Otherwise the dependency isn't installed with the usual `npm install` (as installing with `--save-dev` isn't always possible/desirable).

This fixes the error:

```
$ grunt move
Loading "move.js" tasks...ERROR
>> Error: Cannot find module 'async'
Warning: Task "move" not found. Use --force to continue.

Aborted due to warnings.
```